### PR TITLE
Fix MathML not displaying

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -480,6 +480,9 @@ for version in major_versions:
 
     command_html = command_html.replace("{$examples}", examples_html)
 
+    # Strip 'mml' namespace from MathML tags so that MathJax can find them
+    command_html = re.sub(r'<(/?)mml:(.*?)>', r'<\1\2>', command_html)
+
     output_html = header_for_command + command_html + footer_for_command
 
     output = open(output_dir + version_dir + "/" + command, "w")

--- a/html/header.html
+++ b/html/header.html
@@ -11,6 +11,8 @@
 <link href="../jquery-bonsai/jquery.bonsai.css" rel="stylesheet" type="text/css" />
 <script src="../jquery-cookie/jquery.cookie.js"></script>
 
+<script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML"></script>
+
 <link href="../style.css" rel="stylesheet" type="text/css" />
 <link id="pagestyle" href="../style_light.css" rel="stylesheet" type="text/css" />
 


### PR DESCRIPTION
The MathML on pages like glViewport and glFrustrum is now parsed with
MathJax to make it display correctly in all modern browsers.

Example:

![](http://i.imgur.com/2OqJlh8.png)

Works in latest Chrome, Firefox and IE.
