### PR TITLE
Fix doc on how firstIndex is treated in *DrawElementsIndirect to match the spec

### DIFF
--- a/gl4/glDrawElementsIndirect.xhtml
+++ b/gl4/glDrawElementsIndirect.xhtml
@@ -115,7 +115,7 @@
         glDrawElementsInstancedBaseVertexBaseInstance(mode,
                                                       cmd-&gt;count,
                                                       type,
-                                                      cmd-&gt;firstIndex + size-of-type,
+                                                      cmd-&gt;firstIndex * size-of-type,
                                                       cmd-&gt;primCount,
                                                       cmd-&gt;baseVertex,
                                                       cmd-&gt;baseInstance);

--- a/gl4/glMultiDrawElementsIndirect.xhtml
+++ b/gl4/glMultiDrawElementsIndirect.xhtml
@@ -155,7 +155,7 @@
         glDrawElementsInstancedBaseVertexBaseInstance(mode,
                                                       cmd-&gt;count,
                                                       type,
-                                                      cmd-&gt;firstIndex + size-of-type,
+                                                      cmd-&gt;firstIndex * size-of-type,
                                                       cmd-&gt;instanceCount,
                                                       cmd-&gt;baseVertex,
                                                       cmd-&gt;baseInstance);


### PR DESCRIPTION
There's a small but unfortunate typo in the docs (and in the OpenGL man pages) on how the `firstIndex` member of the `DrawElementsIndirectCommand` struct is treated. The [GL4.3 spec on page 315](https://www.opengl.org/registry/doc/glspec43.core.20130214.pdf)  ([pg. 355 of GL4.5 spec](https://www.opengl.org/registry/doc/glspec45.core.pdf)) states that it's passed to the `indices` parameter of `DrawElementsInstancedBaseVertexBaseInstance` as `cmd->firstIndex * size-of-type` but the docs (and man pages) have a typo and say it's treated as `cmd->firstIndex + size-of-type` which is incorrect.

I'm not sure how to file a bug for the official man pages to have this corrected, but if someone knows please do let me know. Edit: I found their bugzilla and reported the issue there as well.

Thanks!