### PR TITLE
Replace the calls to external programs with the builtin ZipFile API

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -4,6 +4,7 @@ import time
 import sys
 import argparse
 import re
+import zipfile
 
 import opengl
 import shared
@@ -570,9 +571,9 @@ for version in major_versions:
   
   print "Wrote " + str(written) + " commands for " + version
 
-if platform.system() is "Windows":
-  subprocess.call(["\\Program Files\\7-Zip\\7z.exe", "a", "-tzip", "docs.gl.zip", "htdocs"])
-else:
-  subprocess.call(["/usr/bin/zip", "-r", "docs.gl.zip", "htdocs" ])
+with zipfile.ZipFile('docs.gl.zip', 'w', compression=zipfile.ZIP_DEFLATED) as docs_gl_zip:
+  for dirname, _, files in os.walk('htdocs'):
+    for filename in files:
+      docs_gl_zip.write(os.path.join(dirname, filename))
 
 shutil.move("docs.gl.zip", "htdocs/")


### PR DESCRIPTION
This makes the zip creation easier as it doesn’t require the user to install an external program.