### PR TITLE
Note another cause of GL_INVALID_OPERATION

### DIFF
--- a/es3/glTexImage2D.xhtml
+++ b/es3/glTexImage2D.xhtml
@@ -1741,6 +1741,10 @@
             <em class="parameter"><code>format</code></em> and <em class="parameter"><code>type</code></em> is not one of those in the tables above.
         </p>
         <p>
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if storage for the texture has been previously specified with 
+            <a class="citerefentry" href="glTexStorage2D"><span class="citerefentry"><span class="refentrytitle">glTexStorage2D</span></span></a>.
+        </p>
+        <p>
             <code class="constant">GL_INVALID_OPERATION</code> is generated if a non-zero buffer object name is bound to the
             <code class="constant">GL_PIXEL_UNPACK_BUFFER</code> target and the buffer object's data store is currently mapped.
         </p>


### PR DESCRIPTION
glTexStorage2D documents this error cause, but glTexImage2D did not. This only fixes it for es3/2D textures, if this is a good improvement it probably applies to other API levels x texture dimensionalities.