### PR TITLE
Fix MathJax loading

### DIFF
--- a/html/header.html
+++ b/html/header.html
@@ -12,7 +12,7 @@
   <link href="../jquery-bonsai/jquery.bonsai.css" rel="stylesheet" type="text/css" />
   <script src="../jquery-cookie/jquery.cookie.js"></script>
 
-  <script src="http://cdn.mathjax.org/mathjax/1.0-latest/MathJax.js?config=MML_HTMLorMML"></script>
+  <script src="http://cdn.mathjax.org/mathjax/1.1-latest/MathJax.js?config=MML_HTMLorMML"></script>
 
   <link href="../style.css" rel="stylesheet" type="text/css" />
   <link id="pagestyle" href="../style_light.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Commit d12455ec broke MathJax loading. [MathJax 1.0](http://pkra-mathjax-docs.readthedocs.org/en/v1.0/configuration.html) doesn't support chosing a configuration with the `config` query parameter. This feature was introduced with [MathJax 1.1](http://pkra-mathjax-docs.readthedocs.org/en/v1.1-latest/configuration.html).

This PR bumps the MathJax version to 1.1 to fix the issue.

@Sohail05 Could you please check if this reintroduces the "Unknown node type" error you encountered?