### PR TITLE
Fix MathML

### DIFF
--- a/el3/acos.xhtml
+++ b/el3/acos.xhtml
@@ -44,13 +44,13 @@
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>.
             The range of values returned by <code class="function">acos</code> is
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
+                <mml:mfenced open="[" close="]">
                     <mml:mn>0</mml:mn>
-                    <mml:pi definitionURL="" encoding=""/>
-                </mml:list>
+                    <mml:mi>π</mml:mi>
+                </mml:mfenced>
             </mml:math>.
             The result is undefined if
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:gt definitionURL="" encoding=""/><mml:apply><mml:abs definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi></mml:apply><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mo>|</mml:mo><mml:mi mathvariant="italic">x</mml:mi><mml:mo>|</mml:mo><mml:mo>&gt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/el3/acosh.xhtml
+++ b/el3/acosh.xhtml
@@ -43,7 +43,7 @@
             <code class="function">acosh</code> returns the arc hyperbolic cosine of
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>;
             the non-negative inverse of <a class="citerefentry" href="cosh"><span class="citerefentry"><span class="refentrytitle">cosh</span></span></a>. Results
-            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:lt definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi><mml:mo>&lt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/el3/asin.xhtml
+++ b/el3/asin.xhtml
@@ -44,22 +44,22 @@
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>.
             The range of values returned by <code class="function">asin</code> is
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
+                <mml:mfenced open="[" close="]">
                     <mml:mrow>
                         <mml:mo>−</mml:mo>
                         <mml:mfrac>
-                            <mml:pi definitionURL="" encoding=""/>
+                            <mml:mi>π</mml:mi>
                             <mml:mn>2</mml:mn>
                         </mml:mfrac>
                     </mml:mrow>
                     <mml:mfrac>
-                        <mml:pi definitionURL="" encoding=""/>
+                        <mml:mi>π</mml:mi>
                         <mml:mn>2</mml:mn>
                     </mml:mfrac>
-                </mml:list>
+                </mml:mfenced>
             </mml:math>.
             The result is undefined if
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:gt definitionURL="" encoding=""/><mml:apply><mml:abs definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi></mml:apply><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mo>|</mml:mo><mml:mi mathvariant="italic">x</mml:mi><mml:mo>|</mml:mo><mml:mo>&gt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/el3/atan.xhtml
+++ b/el3/atan.xhtml
@@ -94,10 +94,13 @@
             and <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math> are used to determine the quadrant
             that the angle lies in. The values returned by <code class="function">atan</code> in this case are in the range
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
-                    <mml:mrow><mml:mo>−</mml:mo><mml:pi definitionURL="" encoding=""/></mml:mrow>
-                    <mml:pi definitionURL="" encoding=""/>
-                    </mml:list>
+                <mml:mfenced open="[" close="]">
+                    <mml:mrow>
+                        <mml:mo>−</mml:mo>
+                        <mml:mi>π</mml:mi>
+                    </mml:mrow>
+                    <mml:mi>π</mml:mi>
+                </mml:mfenced>
             </mml:math>. Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math> is zero.
         </p>
         <p>
@@ -105,19 +108,19 @@
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">y_over_x</mml:mi></mml:math>. Values
             returned in this case are in the range
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
+                <mml:mfenced open="[" close="]">
                     <mml:mrow>
                         <mml:mo>−</mml:mo>
                         <mml:mfrac>
-                            <mml:pi definitionURL="" encoding=""/>
+                            <mml:mi>π</mml:mi>
                             <mml:mn>2</mml:mn>
                         </mml:mfrac>
                     </mml:mrow>
                     <mml:mfrac>
-                        <mml:pi definitionURL="" encoding=""/>
+                        <mml:mi>π</mml:mi>
                         <mml:mn>2</mml:mn>
                     </mml:mfrac>
-                </mml:list>
+                </mml:mfenced>
             </mml:math>.
         </p>
       </div>

--- a/el3/atanh.xhtml
+++ b/el3/atanh.xhtml
@@ -43,7 +43,7 @@
             <code class="function">atanh</code> returns the arc hyperbolic tangent of
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>;
             the inverse of <a class="citerefentry" href="tanh"><span class="citerefentry"><span class="refentrytitle">tanh</span></span></a>. Results
-            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:gt definitionURL="" encoding=""/><mml:apply><mml:abs definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi></mml:apply><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mo>|</mml:mo><mml:mi mathvariant="italic">x</mml:mi><mml:mo>|</mml:mo><mml:mo>&gt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/el3/cross.xhtml
+++ b/el3/cross.xhtml
@@ -60,71 +60,79 @@
         </p>
         <p>
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:vector>
-                    <mml:csymbol encoding="" definitionURL="">
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo>−</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                    </mml:csymbol>
-                    <mml:csymbol encoding="" definitionURL="">
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>0</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo>−</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>0</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                    </mml:csymbol>
-                    <mml:csymbol encoding="" definitionURL="">
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>0</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo>−</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                    </mml:csymbol>
-                  </mml:vector>
+                <mml:mo>(</mml:mo>
+                <mml:mtable>
+                    <mml:mtr>
+                        <mml:mtd>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo>−</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                        </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                        <mml:mtd>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>0</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo>−</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>0</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                        </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                        <mml:mtd>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>0</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo>−</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                        </mml:mtd>
+                    </mml:mtr>
+                </mml:mtable>
+                <mml:mo>)</mml:mo>
             </mml:math>
         </p>
       </div>

--- a/el3/degrees.xhtml
+++ b/el3/degrees.xhtml
@@ -48,7 +48,7 @@
                         <mml:mn>180</mml:mn><mml:mo>⋅</mml:mo>
                         <mml:mi mathvariant="italic">radians</mml:mi>
                     </mml:mrow>
-                    <mml:pi definitionURL="" encoding=""/>
+                    <mml:mi>π</mml:mi>
                 </mml:mfrac>
             </mml:math>.
         </p>

--- a/el3/inversesqrt.xhtml
+++ b/el3/inversesqrt.xhtml
@@ -42,7 +42,7 @@
         <p>
             <code class="function">inversesqrt</code> returns the inverse of the square root of <em class="parameter"><code>x</code></em>.
             i.e., the value <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mfrac><mml:mn>1</mml:mn><mml:msqrt><mml:mi>x</mml:mi></mml:msqrt></mml:mfrac></mml:math>.
-            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:leq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math>.
+            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>≤</mml:mo><mml:mn>0</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/el3/length.xhtml
+++ b/el3/length.xhtml
@@ -42,26 +42,23 @@
         <p>
             <code class="function">length</code> returns the length of the vector. i.e.,
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:apply>
-                    <mml:root definitionURL="" encoding=""/>
-                    <mml:csymbol encoding="" definitionURL="">
-                        <mml:msup>
-                            <mml:mrow>
-                                <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>0</mml:mn><mml:mo stretchy="false">]</mml:mo>
-                            </mml:mrow>
-                            <mml:mn>2</mml:mn>
-                        </mml:msup>
-                        <mml:mo>+</mml:mo>
-                        <mml:msup>
-                            <mml:mrow>
-                                <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>1</mml:mn><mml:mo stretchy="false">]</mml:mo>
-                            </mml:mrow>
-                            <mml:mn>2</mml:mn>
-                        </mml:msup>
-                        <mml:mo>+</mml:mo>
-                        <mml:mo lspace="0px" form="infix">...</mml:mo>
-                    </mml:csymbol>
-                </mml:apply>
+                <mml:msqrt>
+                    <mml:msup>
+                        <mml:mrow>
+                            <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>0</mml:mn><mml:mo stretchy="false">]</mml:mo>
+                        </mml:mrow>
+                        <mml:mn>2</mml:mn>
+                    </mml:msup>
+                    <mml:mo>+</mml:mo>
+                    <mml:msup>
+                        <mml:mrow>
+                            <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>1</mml:mn><mml:mo stretchy="false">]</mml:mo>
+                        </mml:mrow>
+                        <mml:mn>2</mml:mn>
+                    </mml:msup>
+                    <mml:mo>+</mml:mo>
+                    <mml:mo lspace="0px" form="infix">…</mml:mo>
+                </mml:msqrt>
             </mml:math>
         </p>
       </div>

--- a/el3/log.xhtml
+++ b/el3/log.xhtml
@@ -42,7 +42,7 @@
         <p>
             <code class="function">log</code> returns the natural logarithm of <em class="parameter"><code>x</code></em>. i.e., the value
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>y</mml:mi></mml:math> which satisfies
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:eq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mrow><mml:msup><mml:mi>e</mml:mi><mml:mi>y</mml:mi></mml:msup></mml:mrow></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:msup><mml:mi>e</mml:mi><mml:mi>y</mml:mi></mml:msup></mml:math>.
                         Results are undefined if <em class="parameter"><code>x</code></em> ≤ 0.
         </p>
       </div>

--- a/el3/log2.xhtml
+++ b/el3/log2.xhtml
@@ -42,7 +42,7 @@
         <p>
             <code class="function">log2</code> returns the base 2 logarithm of <em class="parameter"><code>x</code></em>. i.e., the value
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>y</mml:mi></mml:math> which satisfies
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:eq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mrow><mml:msup><mml:mi>2</mml:mi><mml:mi>y</mml:mi></mml:msup></mml:mrow></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:msup><mml:mn>2</mml:mn><mml:mi>y</mml:mi></mml:msup></mml:math>.
                         Results are undefined if <em class="parameter"><code>x</code></em> ≤ 0.
         </p>
       </div>

--- a/el3/radians.xhtml
+++ b/el3/radians.xhtml
@@ -45,7 +45,7 @@
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
                 <mml:mfrac>
                     <mml:mrow>
-                        <mml:pi definitionURL="" encoding=""/><mml:mo>⋅</mml:mo><mml:mi mathvariant="italic">degrees</mml:mi>
+                        <mml:mi>π</mml:mi><mml:mo>⋅</mml:mo><mml:mi mathvariant="italic">degrees</mml:mi>
                     </mml:mrow>
                     <mml:mn>180</mml:mn>
                 </mml:mfrac>

--- a/el3/sign.xhtml
+++ b/el3/sign.xhtml
@@ -52,11 +52,11 @@
         <h2>Description</h2>
         <p>
             <code class="function">sign</code> returns -1.0 if
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:lt definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0.0</mml:mn></mml:apply></mml:math>,
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>&lt;</mml:mo><mml:mn>0.0</mml:mn></mml:math>,
             0.0 if
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:eq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0.0</mml:mn></mml:apply></mml:math> and
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mn>0.0</mml:mn></mml:math> and
             1.0 if
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:gt definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0.0</mml:mn></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>&gt;</mml:mo><mml:mn>0.0</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/el3/sqrt.xhtml
+++ b/el3/sqrt.xhtml
@@ -42,7 +42,7 @@
         <p>
             <code class="function">sqrt</code> returns the square root of <em class="parameter"><code>x</code></em>. i.e., the value
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:msqrt><mml:mi>x</mml:mi></mml:msqrt></mml:math>.
-            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:lt definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math>.
+            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>&lt;</mml:mo><mml:mn>0</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/es3/glPixelStorei.xhtml
+++ b/es3/glPixelStorei.xhtml
@@ -926,7 +926,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -946,7 +946,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -966,7 +966,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -986,7 +986,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -1006,7 +1006,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -1040,7 +1040,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -1060,7 +1060,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -1080,7 +1080,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -1100,7 +1100,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>
@@ -1120,7 +1120,7 @@
                             
                             <mfenced open="[" close=")">
                                 <mn>0</mn>
-                                <infinity definitionURL="" encoding=""/>
+                                <mn>∞</mn>
                             </mfenced>
                         </math>
                         </td>

--- a/gl2/glPixelStore.xhtml
+++ b/gl2/glPixelStore.xhtml
@@ -917,7 +917,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -931,7 +931,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -945,7 +945,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -959,7 +959,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -973,7 +973,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1011,7 +1011,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1025,7 +1025,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1039,7 +1039,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1053,7 +1053,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1067,7 +1067,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">

--- a/gl2/glPixelTransfer.xhtml
+++ b/gl2/glPixelTransfer.xhtml
@@ -339,9 +339,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -356,9 +356,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -373,9 +373,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -390,9 +390,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -407,9 +407,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -424,9 +424,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -441,9 +441,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -458,9 +458,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -475,9 +475,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -492,9 +492,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -509,9 +509,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -526,9 +526,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -543,9 +543,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -560,9 +560,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -577,9 +577,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -594,9 +594,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -611,9 +611,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -628,9 +628,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -645,9 +645,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -662,9 +662,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -679,9 +679,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -696,9 +696,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -713,9 +713,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -730,9 +730,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -747,9 +747,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -764,9 +764,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -781,9 +781,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -798,9 +798,9 @@
                             <mml:mfenced open="(" close=")">
                                 <mml:mrow>
                                     <mml:mo>-</mml:mo>
-                                    <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                    <mml:mn>∞</mml:mn>
                                 </mml:mrow>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr></tbody></table></div><p>

--- a/gl3/glPixelStore.xhtml
+++ b/gl3/glPixelStore.xhtml
@@ -895,7 +895,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -909,7 +909,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -923,7 +923,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -937,7 +937,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -951,7 +951,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -989,7 +989,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1003,7 +1003,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1017,7 +1017,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1031,7 +1031,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">
@@ -1045,7 +1045,7 @@
                             
                             <mml:mfenced open="[" close=")">
                                 <mml:mn>0</mml:mn>
-                                <mml:infinity definitionURL="" encoding=""></mml:infinity>
+                                <mml:mn>∞</mml:mn>
                             </mml:mfenced>
                         </mml:math>
                         </td></tr><tr><td align="left">

--- a/gl3/glTexBuffer.xhtml
+++ b/gl3/glTexBuffer.xhtml
@@ -16,16 +16,18 @@
             When a buffer object is attached to a buffer texture, the buffer object's data store
             is taken as the texture's texel array.  The number of texels in the buffer texture's
             texel array is given by
-        </p><mml:apply xmlns:mml="http://www.w3.org/1998/Math/MathML"><mml:floor definitionURL="" encoding=""></mml:floor>
-                <mml:mfrac>
-                    <mml:mrow>
-                        <mml:mi>buffer_size</mml:mi>
-                    </mml:mrow>
-                    <mml:mrow>
-                        <mml:mi>components</mml:mi><mml:mo> </mml:mo><mml:csymbol encoding="" definitionURL=""><mml:mo>×</mml:mo></mml:csymbol><mml:mo> </mml:mo><mml:mi>sizeof</mml:mi><mml:mo>(</mml:mo><mml:mi>base_type</mml:mi><mml:mo>)</mml:mo>
-                    </mml:mrow>
-                </mml:mfrac>
-            </mml:apply><p>
+        </p><mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
+            <mml:mo>⌊</mml:mo>
+            <mml:mfrac>
+                <mml:mrow>
+                    <mml:mi>buffer_size</mml:mi>
+                </mml:mrow>
+                <mml:mrow>
+                    <mml:mi>components</mml:mi><mml:mo>×</mml:mo><mml:mi>sizeof</mml:mi><mml:mo>(</mml:mo><mml:mi>base_type</mml:mi><mml:mo>)</mml:mo>
+                </mml:mrow>
+            </mml:mfrac>
+            <mml:mo>⌋</mml:mo>
+        </mml:math><p>
             where <span class="emphasis"><em>buffer_size</em></span> is the size of the buffer object, in basic machine units and
             components and base type are the element count and base data type for elements, as specified in the table above.
             The number of texels in the texel array is then clamped to the implementation-dependent limit <code class="constant">GL_MAX_TEXTURE_BUFFER_SIZE</code>.

--- a/html/header.html
+++ b/html/header.html
@@ -12,7 +12,7 @@
   <link href="../jquery-bonsai/jquery.bonsai.css" rel="stylesheet" type="text/css" />
   <script src="../jquery-cookie/jquery.cookie.js"></script>
 
-  <script src="http://cdn.mathjax.org/mathjax/1.0-latest/MathJax.js?config=MML_HTMLorMML"></script>
+  <script src="http://cdn.mathjax.org/mathjax/1.1-latest/MathJax.js?config=MML_HTMLorMML"></script>
 
   <link href="../style.css" rel="stylesheet" type="text/css" />
   <link id="pagestyle" href="../style_light.css" rel="stylesheet" type="text/css" />

--- a/html/header.html
+++ b/html/header.html
@@ -12,7 +12,7 @@
   <link href="../jquery-bonsai/jquery.bonsai.css" rel="stylesheet" type="text/css" />
   <script src="../jquery-cookie/jquery.cookie.js"></script>
 
-  <script src="http://cdn.mathjax.org/mathjax/1.1-latest/MathJax.js?config=MML_HTMLorMML"></script>
+  <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML"></script>
 
   <link href="../style.css" rel="stylesheet" type="text/css" />
   <link id="pagestyle" href="../style_light.css" rel="stylesheet" type="text/css" />

--- a/sl4/acos.xhtml
+++ b/sl4/acos.xhtml
@@ -44,13 +44,13 @@
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>.
             The range of values returned by <code class="function">acos</code> is
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
+                <mml:mfenced open="[" close="]">
                     <mml:mn>0</mml:mn>
-                    <mml:pi definitionURL="" encoding=""/>
-                </mml:list>
+                    <mml:mi>π</mml:mi>
+                </mml:mfenced>
             </mml:math>.
             The result is undefined if
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:gt definitionURL="" encoding=""/><mml:apply><mml:abs definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi></mml:apply><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mo>|</mml:mo><mml:mi mathvariant="italic">x</mml:mi><mml:mo>|</mml:mo><mml:mo>&gt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/acosh.xhtml
+++ b/sl4/acosh.xhtml
@@ -43,7 +43,7 @@
             <code class="function">acosh</code> returns the arc hyperbolic cosine of
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>;
             the non-negative inverse of <a class="citerefentry" href="cosh"><span class="citerefentry"><span class="refentrytitle">cosh</span></span></a>. Results
-            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:lt definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi><mml:mo>&lt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/asin.xhtml
+++ b/sl4/asin.xhtml
@@ -44,22 +44,22 @@
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>.
             The range of values returned by <code class="function">asin</code> is
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
+                <mml:mfenced open="[" close="]">
                     <mml:mrow>
                         <mml:mo>−</mml:mo>
                         <mml:mfrac>
-                            <mml:pi definitionURL="" encoding=""/>
+                            <mml:mi>π</mml:mi>
                             <mml:mn>2</mml:mn>
                         </mml:mfrac>
                     </mml:mrow>
                     <mml:mfrac>
-                        <mml:pi definitionURL="" encoding=""/>
+                        <mml:mi>π</mml:mi>
                         <mml:mn>2</mml:mn>
                     </mml:mfrac>
-                </mml:list>
+                </mml:mfenced>
             </mml:math>.
             The result is undefined if
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:gt definitionURL="" encoding=""/><mml:apply><mml:abs definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi></mml:apply><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mo>|</mml:mo><mml:mi mathvariant="italic">x</mml:mi><mml:mo>|</mml:mo><mml:mo>&gt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/atan.xhtml
+++ b/sl4/atan.xhtml
@@ -95,10 +95,13 @@
             and <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math> are used to determine the quadrant
             that the angle lies in. The values returned by <code class="function">atan</code> in this case are in the range
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
-                    <mml:mrow><mml:mo>−</mml:mo><mml:pi definitionURL="" encoding=""/></mml:mrow>
-                    <mml:pi definitionURL="" encoding=""/>
-                </mml:list>
+                <mml:mfenced open="[" close="]">
+                    <mml:mrow>
+                        <mml:mo>−</mml:mo>
+                        <mml:mi>π</mml:mi>
+                    </mml:mrow>
+                    <mml:mi>π</mml:mi>
+                </mml:mfenced>
             </mml:math>. Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math> is zero.
         </p>
         <p>
@@ -106,19 +109,19 @@
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">y_over_x</mml:mi></mml:math>. Values
             returned in this case are in the range
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:list order="numeric">
+                <mml:mfenced open="[" close="]">
                     <mml:mrow>
                         <mml:mo>−</mml:mo>
                         <mml:mfrac>
-                            <mml:pi definitionURL="" encoding=""/>
+                            <mml:mi>π</mml:mi>
                             <mml:mn>2</mml:mn>
                         </mml:mfrac>
                     </mml:mrow>
                     <mml:mfrac>
-                        <mml:pi definitionURL="" encoding=""/>
+                        <mml:mi>π</mml:mi>
                         <mml:mn>2</mml:mn>
                     </mml:mfrac>
-                </mml:list>
+                </mml:mfenced>
             </mml:math>.
         </p>
       </div>

--- a/sl4/atanh.xhtml
+++ b/sl4/atanh.xhtml
@@ -43,7 +43,7 @@
             <code class="function">atanh</code> returns the arc hyperbolic tangent of
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi mathvariant="italic">x</mml:mi></mml:math>;
             the inverse of <a class="citerefentry" href="tanh"><span class="citerefentry"><span class="refentrytitle">tanh</span></span></a>. Results
-            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:gt definitionURL="" encoding=""/><mml:apply><mml:abs definitionURL="" encoding=""/><mml:mi mathvariant="italic">x</mml:mi></mml:apply><mml:mn>1</mml:mn></mml:apply></mml:math>.
+            are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mo>|</mml:mo><mml:mi mathvariant="italic">x</mml:mi><mml:mo>|</mml:mo><mml:mo>&gt;</mml:mo><mml:mn>1</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/cross.xhtml
+++ b/sl4/cross.xhtml
@@ -73,71 +73,79 @@
         </p>
         <p>
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:vector>
-                    <mml:csymbol encoding="" definitionURL="">
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo>−</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                    </mml:csymbol>
-                    <mml:csymbol encoding="" definitionURL="">
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>0</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo>−</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>2</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>0</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                    </mml:csymbol>
-                    <mml:csymbol encoding="" definitionURL="">
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>0</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo>−</mml:mo>
-                      <mml:mi>y</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>0</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                      <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
-                      <mml:mi>x</mml:mi>
-                      <mml:mo stretchy="false">[</mml:mo>
-                      <mml:mn>1</mml:mn>
-                      <mml:mo stretchy="false">]</mml:mo>
-                    </mml:csymbol>
-                  </mml:vector>
+                <mml:mo>(</mml:mo>
+                <mml:mtable>
+                    <mml:mtr>
+                        <mml:mtd>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo>−</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                        </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                        <mml:mtd>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>0</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo>−</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>2</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>0</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                        </mml:mtd>
+                    </mml:mtr>
+                    <mml:mtr>
+                        <mml:mtd>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>0</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo>−</mml:mo>
+                            <mml:mi>y</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                            <mml:mo lspace="2px" rspace="2px">⋅</mml:mo>
+                            <mml:mi>x</mml:mi>
+                            <mml:mo stretchy="false">[</mml:mo>
+                            <mml:mn>1</mml:mn>
+                            <mml:mo stretchy="false">]</mml:mo>
+                        </mml:mtd>
+                    </mml:mtr>
+                </mml:mtable>
+                <mml:mo>)</mml:mo>
             </mml:math>
         </p>
       </div>

--- a/sl4/degrees.xhtml
+++ b/sl4/degrees.xhtml
@@ -49,7 +49,7 @@
                         <mml:mn>180</mml:mn><mml:mo>⋅</mml:mo>
                         <mml:mi mathvariant="italic">radians</mml:mi>
                     </mml:mrow>
-                    <mml:pi definitionURL="" encoding=""/>
+                    <mml:mi>π</mml:mi>
                 </mml:mfrac>
             </mml:math>.
         </p>

--- a/sl4/inversesqrt.xhtml
+++ b/sl4/inversesqrt.xhtml
@@ -53,7 +53,7 @@
         <p>
             <code class="function">inversesqrt</code> returns the inverse of the square root of <em class="parameter"><code>x</code></em>.
             i.e., the value <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mfrac><mml:mn>1</mml:mn><mml:msqrt><mml:mi>x</mml:mi></mml:msqrt></mml:mfrac></mml:math>.
-            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:leq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math>.
+            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>≤</mml:mo><mml:mn>0</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/length.xhtml
+++ b/sl4/length.xhtml
@@ -51,26 +51,23 @@
         <p>
             <code class="function">length</code> returns the length of the vector. i.e.,
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll">
-                <mml:apply>
-                    <mml:root definitionURL="" encoding=""/>
-                    <mml:csymbol encoding="" definitionURL="">
-                        <mml:msup>
-                            <mml:mrow>
-                                <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>0</mml:mn><mml:mo stretchy="false">]</mml:mo>
-                            </mml:mrow>
-                            <mml:mn>2</mml:mn>
-                        </mml:msup>
-                        <mml:mo>+</mml:mo>
-                        <mml:msup>
-                            <mml:mrow>
-                                <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>1</mml:mn><mml:mo stretchy="false">]</mml:mo>
-                            </mml:mrow>
-                            <mml:mn>2</mml:mn>
-                        </mml:msup>
-                        <mml:mo>+</mml:mo>
-                        <mml:mo lspace="0px" form="infix">...</mml:mo>
-                    </mml:csymbol>
-                </mml:apply>
+                <mml:msqrt>
+                    <mml:msup>
+                        <mml:mrow>
+                            <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>0</mml:mn><mml:mo stretchy="false">]</mml:mo>
+                        </mml:mrow>
+                        <mml:mn>2</mml:mn>
+                    </mml:msup>
+                    <mml:mo>+</mml:mo>
+                    <mml:msup>
+                        <mml:mrow>
+                            <mml:mi>x</mml:mi><mml:mo stretchy="false">[</mml:mo><mml:mn>1</mml:mn><mml:mo stretchy="false">]</mml:mo>
+                        </mml:mrow>
+                        <mml:mn>2</mml:mn>
+                    </mml:msup>
+                    <mml:mo>+</mml:mo>
+                    <mml:mo form="infix">…</mml:mo>
+                </mml:msqrt>
             </mml:math>
         </p>
       </div>

--- a/sl4/log.xhtml
+++ b/sl4/log.xhtml
@@ -42,7 +42,7 @@
         <p>
             <code class="function">log</code> returns the natural logarithm of <em class="parameter"><code>x</code></em>. i.e., the value
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>y</mml:mi></mml:math> which satisfies
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:eq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mrow><mml:msup><mml:mi>e</mml:mi><mml:mi>y</mml:mi></mml:msup></mml:mrow></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:msup><mml:mi>e</mml:mi><mml:mi>y</mml:mi></mml:msup></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/log2.xhtml
+++ b/sl4/log2.xhtml
@@ -42,8 +42,8 @@
         <p>
             <code class="function">log2</code> returns the base 2 logarithm of <em class="parameter"><code>x</code></em>. i.e., the value
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>y</mml:mi></mml:math> which satisfies
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:eq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mrow><mml:msup><mml:mi>2</mml:mi><mml:mi>y</mml:mi></mml:msup></mml:mrow></mml:apply></mml:math>.
-            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:leq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math>.
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:msup><mml:mn>2</mml:mn><mml:mi>y</mml:mi></mml:msup></mml:math>.
+            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>≤</mml:mo><mml:mn>0</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/pow.xhtml
+++ b/sl4/pow.xhtml
@@ -58,9 +58,9 @@
         <p>
             <code class="function">pow</code> returns the value of <em class="parameter"><code>x</code></em> raised to the <em class="parameter"><code>y</code></em> power. i.e.,
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:msup><mml:mi>x</mml:mi><mml:mi>y</mml:mi></mml:msup></mml:math>.
-            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:lt definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math>
-            or if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:eq definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math> and
-            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:eq definitionURL="" encoding=""/><mml:mi>y</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math>.
+            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>&lt;</mml:mo></mml:math>
+            or if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:math> and
+            <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>y</mml:mi><mml:mo>=</mml:mo><mml:mn>0</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}

--- a/sl4/radians.xhtml
+++ b/sl4/radians.xhtml
@@ -46,7 +46,7 @@
                 
                 <mml:mfrac>
                     <mml:mrow>
-                        <mml:pi definitionURL="" encoding=""/><mml:mo>⋅</mml:mo><mml:mi mathvariant="italic">degrees</mml:mi>
+                        <mml:mi>π</mml:mi><mml:mo>⋅</mml:mo><mml:mi mathvariant="italic">degrees</mml:mi>
                     </mml:mrow>
                     <mml:mn>180</mml:mn>
                 </mml:mfrac>

--- a/sl4/sqrt.xhtml
+++ b/sl4/sqrt.xhtml
@@ -53,7 +53,7 @@
         <p>
             <code class="function">sqrt</code> returns the square root of <em class="parameter"><code>x</code></em>. i.e., the value
             <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:msqrt><mml:mi>x</mml:mi></mml:msqrt></mml:math>.
-            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:apply><mml:lt definitionURL="" encoding=""/><mml:mi>x</mml:mi><mml:mn>0</mml:mn></mml:apply></mml:math>.
+            Results are undefined if <mml:math xmlns:mml="http://www.w3.org/1998/Math/MathML" overflow="scroll"><mml:mi>x</mml:mi><mml:mo>&lt;</mml:mo><mml:mn>0</mml:mn></mml:math>.
         </p>
       </div>
       {$pipelinestall}{$examples}


### PR DESCRIPTION
Follow-up to #33.

The OpenGL documentation mixes MathML content markup with presentation markup, which MathJax cannot deal with. Replacing content markup with equivalent presentation markup (using http://www.w3.org/TR/MathML3/chapter4.html as a reference) fixes the issue.

Please let me know if there are any other outstanding MathML issues, and I'll look into them.