### PR TITLE
Fix parameter documentation for glVertexAttribFormat

### DIFF
--- a/gl4/glVertexAttribFormat.xhtml
+++ b/gl4/glVertexAttribFormat.xhtml
@@ -210,7 +210,7 @@
               </span>
             </dt>
             <dd>
-              <p>The distance between elements within the buffer.</p>
+              <p><code class="constant">GL_TRUE</code> if the parameter represents a normalized integer (<em class="parameter"><code>type</code></em> must be an integer type). <code class="constant">GL_FALSE</code> otherwise.</p>
             </dd>
             <dt>
               <span class="term">
@@ -220,7 +220,7 @@
               </span>
             </dt>
             <dd>
-              <p>The distance between elements within the buffer.</p>
+              <p>The offset, measured in basic machine units of the first element relative to the start of the vertex buffer binding this attribute fetches from.</p>
             </dd>
           </dl>
         </div>


### PR DESCRIPTION
Description for the parameters `normalized` and `relativeoffset` was wrong. Fixed wording was taken from https://www.opengl.org/wiki/GLAPI/glVertexAttribFormat