### PR TITLE
atomicCounterDecrement : fix the return value statement.

### DIFF
--- a/sl4/atomicCounterDecrement.xhtml
+++ b/sl4/atomicCounterDecrement.xhtml
@@ -2,7 +2,7 @@
       <div class="titlepage"></div>
       <div class="refnamediv">
         <h2>Name</h2>
-        <p>atomicCounterDecrement — atomically decrement a counter and return the prior value</p>
+        <p>atomicCounterDecrement — atomically decrement a counter and return its new value</p>
       </div>
       <div class="refsynopsisdiv">
         <h2>Declaration</h2>


### PR DESCRIPTION
Unlike atomicCounterIncrement, _atomicCounterDecrement_ returns the **modified** value of the counter.
See also: [OpenGL wiki > Atomic Counter](https://www.opengl.org/wiki/Atomic_Counter).

PS : The [official documentation](https://www.opengl.org/sdk/docs/man4/) has the same typo.