### PR TITLE
Fix gl_FragDepth documentation.

### DIFF
--- a/sl4/gl_FragDepth.xhtml
+++ b/sl4/gl_FragDepth.xhtml
@@ -17,7 +17,7 @@
             depth will be used (this value is contained in the z component of <a class="citerefentry" href="gl_FragCoord"><span class="citerefentry"><span class="refentrytitle">gl_FragCoord</span></span></a>)
             otherwise, the value written to <code class="varname">gl_FragDepth</code> is used.
             If a shader statically assigns to <code class="varname">gl_FragDepth</code>, then the value of the fragment's depth
-            may be undefined for executions of the shader that take that path. That is, if the set of linked fragment
+            may be undefined for executions of the shader that don't take that path. That is, if the set of linked fragment
             shaders statically contain a write to <code class="varname">gl_FragDepth</code>, then it is responsible for always
             writing it.
         </p>


### PR DESCRIPTION
The depth value may be undefined if it _isn't_ assigned and there is another static assignment in the shader.