### PR TITLE
Fixed Function Signatures in gl4/glBindBufferRange

### DIFF
--- a/gl4/glBindBufferRange.xhtml
+++ b/gl4/glBindBufferRange.xhtml
@@ -12,23 +12,23 @@
               <td>
                 <code class="funcdef">void <strong class="fsfunc">glBindBufferRange</strong>(</code>
               </td>
-              <td>GLenum<var class="pdparam">target</var>, </td>
+              <td>GLenum <var class="pdparam">target</var>, </td>
             </tr>
             <tr>
               <td> </td>
-              <td>GLuint<var class="pdparam">index</var>, </td>
+              <td>GLuint <var class="pdparam">index</var>, </td>
             </tr>
             <tr>
               <td> </td>
-              <td>GLuint<var class="pdparam">buffer</var>, </td>
+              <td>GLuint <var class="pdparam">buffer</var>, </td>
             </tr>
             <tr>
               <td> </td>
-              <td>GLintptr<var class="pdparam">offset</var>, </td>
+              <td>GLintptr <var class="pdparam">offset</var>, </td>
             </tr>
             <tr>
               <td> </td>
-              <td>GLsizeiptr<var class="pdparam">size</var><code>)</code>;</td>
+              <td>GLsizeiptr <var class="pdparam">size</var><code>)</code>;</td>
             </tr>
           </table>
           <div class="funcprototype-spacer"> </div>


### PR DESCRIPTION
Added space between type and variable name in function signatures of gl4/glBindBufferRange.