### PR TITLE
Update glMapBuffer.xhtml 

### DIFF
--- a/es3/glMapBufferRange.xhtml
+++ b/es3/glMapBufferRange.xhtml
@@ -228,7 +228,9 @@
             Mappings to the data stores of buffer objects may have nonstandard performance characteristics.
             For example, such mappings may be marked as uncacheable regions of memory, and in such cases reading from them may be very slow.
             To ensure optimal performance, the client should use the mapping in a fashion consistent
-            with the values of  <code class="constant">GL_BUFFER_USAGE</code> and <em class="parameter"><code>access</code></em>.
+            with the values of <code class="constant">GL_BUFFER_USAGE</code> (see <code class="function">glGetBufferParameter</code>
+	    and <em class="parameter"><code>usage</code></em> of <code class="function">glBufferData</code>)
+	    and <em class="parameter"><code>access</code></em>.
             Using a mapping in a fashion inconsistent with these values is liable to be multiple orders of magnitude slower
             than using normal memory.
         </p>

--- a/gl4/glMapBuffer.xhtml
+++ b/gl4/glMapBuffer.xhtml
@@ -276,9 +276,10 @@
             mappings may be marked as uncacheable regions of memory, and in
             such cases reading from them may be very slow. To ensure optimal
             performance, the client should use the mapping in a fashion
-            consistent with the <em class="parameter"><code>usage</code></em>
-            (see <code class="function">glMapBuffer</code>) of the buffer object
-            and of <em class="parameter"><code>access</code></em>.
+            consistent with <code class="constant">GL_BUFFER_USAGE</code> (see
+            <code class="function">glGet*BufferParameter</code> and
+            <em class="parameter"><code>usage</code></em> of <code class="function">glBufferData</code>)
+            for the buffer object and of <em class="parameter"><code>access</code></em>.
             Using a mapping in a fashion inconsistent with these values is liable
             to be multiple orders of magnitude slower than using normal memory.
         </p>

--- a/gl4/glMapBuffer.xhtml
+++ b/gl4/glMapBuffer.xhtml
@@ -276,11 +276,11 @@
             mappings may be marked as uncacheable regions of memory, and in
             such cases reading from them may be very slow. To ensure optimal
             performance, the client should use the mapping in a fashion
-            consistent with the values of
-            <code class="constant">GL_BUFFER_USAGE</code> for the buffer object and
-            of <em class="parameter"><code>access</code></em>. Using a mapping in a fashion
-            inconsistent with these values is liable to be multiple orders
-            of magnitude slower than using normal memory.
+            consistent with the <em class="parameter"><code>usage</code></em>
+            (see <code class="function">glMapBuffer</code>) of the buffer object
+            and of <em class="parameter"><code>access</code></em>.
+            Using a mapping in a fashion inconsistent with these values is liable
+            to be multiple orders of magnitude slower than using normal memory.
         </p>
       </div>
       <div class="refsect1" id="notes">

--- a/gl4/glMapBuffer.xhtml
+++ b/gl4/glMapBuffer.xhtml
@@ -277,8 +277,8 @@
             such cases reading from them may be very slow. To ensure optimal
             performance, the client should use the mapping in a fashion
             consistent with <code class="constant">GL_BUFFER_USAGE</code> (see
-            <code class="function">glGet*BufferParameter</code> and
-            <em class="parameter"><code>usage</code></em> of <code class="function">glBufferData</code>)
+            <code class="function">glGet*BufferParameter</code> and <em class="parameter">
+            <code>usage</code></em> of <code class="function">glBufferData</code>)
             for the buffer object and of <em class="parameter"><code>access</code></em>.
             Using a mapping in a fashion inconsistent with these values is liable
             to be multiple orders of magnitude slower than using normal memory.

--- a/gl4/glMapBufferRange.xhtml
+++ b/gl4/glMapBufferRange.xhtml
@@ -413,7 +413,9 @@
             such cases reading from them may be very slow. To ensure optimal
             performance, the client should use the mapping in a fashion
             consistent with the values of
-            <code class="constant">GL_BUFFER_USAGE</code> for the buffer object and
+            <code class="constant">GL_BUFFER_USAGE</code> (see <code class="function">
+            glGet*BufferParameter</code> and <em class="parameter"><code>usage</code></em>
+            of <code class="function">glBufferData</code>) for the buffer object and
             of <em class="parameter"><code>access</code></em>. Using a mapping in a fashion
             inconsistent with these values is liable to be multiple orders
             of magnitude slower than using normal memory.


### PR DESCRIPTION
GL_BUFFER_USAGE is not a constant or enum. The original "BUFFER_USAGE" name is part of the internal state of a buffer object, and comes from the original text found in the Opengl spec document. See Table 6.3 in the Opengl v4.6 spec.
If this update is accepted, it should be done on glMapBufferRange as well.