### PR TITLE
Minor Typo in Function Name

### DIFF
--- a/sl4/isnan.xhtml
+++ b/sl4/isnan.xhtml
@@ -49,7 +49,7 @@
       <div class="refsect1" id="description">
         <h2>Description</h2>
         <p>
-            For each element element <span class="emphasis"><em>i</em></span> of the result, <code class="function">isinf</code> returns <code class="constant">true</code> if
+            For each element element <span class="emphasis"><em>i</em></span> of the result, <code class="function">isnan</code> returns <code class="constant">true</code> if
             <em class="parameter"><code>x</code></em>[<span class="emphasis"><em>i</em></span>] is posititve or negative floating point NaN (Not a Number) and false otherwise.
         </p>
       </div>


### PR DESCRIPTION
Fix typo in function name, 'isinf' to 'isnan'