### PR TITLE
Support local copies of all remote assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,8 @@
 /*.pyc
 /html/copy/jquery-ui.min.js
 /html/copy/jquery.min.js
+/html/copy/MathJax.js
+/html/copy/config
+/html/copy/jax
+/html/copy/*.woff
 .DS_Store

--- a/html/header.html
+++ b/html/header.html
@@ -5,14 +5,14 @@
   <title>{$command} - {$api_name} {$command_major_version} - docs.gl</title>
 
   <link rel="shortcut icon" href="/favicon.ico" />
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+  {$jquery}
   <link rel="stylesheet" href="../jquery-ui.css" />
-  <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1.11.0/jquery-ui.min.js"></script>
+  {$jqueryui}
   <script src="../jquery-bonsai/jquery.bonsai.js"></script>
   <link href="../jquery-bonsai/jquery.bonsai.css" rel="stylesheet" type="text/css" />
   <script src="../jquery-cookie/jquery.cookie.js"></script>
 
-  <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=MML_HTMLorMML"></script>
+  {$mathjax}
 
   <link href="../style.css" rel="stylesheet" type="text/css" />
   <link id="pagestyle" href="../style_light.css" rel="stylesheet" type="text/css" />

--- a/html/style.css
+++ b/html/style.css
@@ -55,14 +55,14 @@ table {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Regular'), local('Roboto-Regular'), url(http://fonts.gstatic.com/s/roboto/v13/2UX7WLTfW3W8TclTUvlFyQ.woff) format('woff');
+  src: local('Roboto Regular'), local('Roboto-Regular'), url({$roboto}) format('woff');
 }
 
 @font-face {
   font-family: 'Source Code Pro';
   font-style: normal;
   font-weight: 400;
-  src: local('Source Code Pro'), local('SourceCodePro-Regular'), url(http://fonts.gstatic.com/s/sourcecodepro/v5/mrl8jkM18OlOQN8JLgasDxM0YzuT7MdOe03otPbuUS0.woff) format('woff');
+  src: local('Source Code Pro'), local('SourceCodePro-Regular'), url({$sourcecodepro}) format('woff');
 }
 
 body {

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,12 @@ HTML minification and Unicode processing as well. It looks like this:
 
 	python compile.py --full
 
+If you want to build a copy that can be used offline, then you can use the `--local-assets`
+parameter which downloads the fonts and Javascript libraries. It then builds the HTML and CSS
+using the local copies. It looks like this:
+
+	python compile.py --local-assets
+
 If you are running Windows, there are a build.bat and a build_full.bat for convenience. When
 the script is done building, the completed site will be in a folder named `htdocs`.
 


### PR DESCRIPTION
Adds an extra --local-assets parameter to compile.py to download the javascript and fonts locally. This is so the docs can be used offline. Leaving off this parameter will keep the old behavior.