### PR TITLE
Fixed typo

### DIFF
--- a/sl4/textureGather.xhtml
+++ b/sl4/textureGather.xhtml
@@ -248,7 +248,7 @@
         <p>
     </p>
         <p>
-        If specified, the value of <em class="parameter"><code>comp</code></em> must ba constant integer expression with a value
+        If specified, the value of <em class="parameter"><code>comp</code></em> must be a constant integer expression with a value
         of 0, 1, 2, or 3, identifying the x, y, z or w component of the four-component vector lookup result for each
         texel, respectively. If <em class="parameter"><code>comp</code></em> is not specified, it is treated as 0, selecting the x
         component of each texel to generate the result.


### PR DESCRIPTION
Was "must ba constant". Now "must be a constant".