### PR TITLE
Add GL_INVALID_OPERATION error.

### DIFF
--- a/gl4/glVertexAttribDivisor.xhtml
+++ b/gl4/glVertexAttribDivisor.xhtml
@@ -78,6 +78,9 @@
             <code class="constant">GL_INVALID_VALUE</code> is generated if <em class="parameter"><code>index</code></em> is greater
             than or equal to the value of <code class="constant">GL_MAX_VERTEX_ATTRIBS</code>.
         </p>
+        <p>
+            <code class="constant">GL_INVALID_OPERATION</code> is generated if no vertex array object is bound.
+        </p>
       </div>
       {$pipelinestall}{$examples}
       <div class="refsect1" id="versions">


### PR DESCRIPTION
According to https://www.khronos.org/opengl/wiki/GLAPI/glVertexAttribDivisor, this function not only will generate GL_INVALID_VALUE error, but also will generate GL_INVALID_OPERATION error.