### PR TITLE
Remove link to glUseShaderPrograms

### DIFF
--- a/es3/glDeleteProgramPipelines.xhtml
+++ b/es3/glDeleteProgramPipelines.xhtml
@@ -123,7 +123,6 @@
             <a class="citerefentry" href="glGenProgramPipelines"><span class="citerefentry"><span class="refentrytitle">glGenProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>

--- a/es3/glGenProgramPipelines.xhtml
+++ b/es3/glGenProgramPipelines.xhtml
@@ -125,7 +125,6 @@
             <a class="citerefentry" href="glDeleteProgramPipelines"><span class="citerefentry"><span class="refentrytitle">glDeleteProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>

--- a/gl4/glDeleteProgramPipelines.xhtml
+++ b/gl4/glDeleteProgramPipelines.xhtml
@@ -168,7 +168,6 @@
             <a class="citerefentry" href="glGenProgramPipelines"><span class="citerefentry"><span class="refentrytitle">glGenProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>

--- a/gl4/glGenProgramPipelines.xhtml
+++ b/gl4/glGenProgramPipelines.xhtml
@@ -170,7 +170,6 @@
             <a class="citerefentry" href="glDeleteProgramPipelines"><span class="citerefentry"><span class="refentrytitle">glDeleteProgramPipelines</span></span></a>,
             <a class="citerefentry" href="glBindProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glBindProgramPipeline</span></span></a>,
             <a class="citerefentry" href="glIsProgramPipeline"><span class="citerefentry"><span class="refentrytitle">glIsProgramPipeline</span></span></a>,
-            <a class="citerefentry" href="glUseShaderPrograms"><span class="citerefentry"><span class="refentrytitle">glUseShaderPrograms</span></span></a>,
             <a class="citerefentry" href="glUseProgram"><span class="citerefentry"><span class="refentrytitle">glUseProgram</span></span></a>
         </p>
       </div>


### PR DESCRIPTION
glUseShaderPrograms is not an OpenGL function, and the page does not exist in the documentation. This error exists in the khronos [documentation](https://www.khronos.org/registry/OpenGL-Refpages/es3.1/html/glUseShaderPrograms.xhtml) as well, I suspect that is how it ended up here.