### PR TITLE
Separate sentences with a dot

### DIFF
--- a/gl4/glDebugMessageCallback.xhtml
+++ b/gl4/glDebugMessageCallback.xhtml
@@ -76,7 +76,7 @@
             Each time a debug message is generated the debug callback function will be invoked
             with <em class="parameter"><code>source</code></em>, <em class="parameter"><code>type</code></em>, <em class="parameter"><code>id</code></em>, and
             <em class="parameter"><code>severity</code></em> associated with the message, and <em class="parameter"><code>length</code></em> set to
-            the length of debug message whose character string is in the array pointed to by <em class="parameter"><code>message</code></em>
+            the length of debug message whose character string is in the array pointed to by <em class="parameter"><code>message</code></em>.
             <em class="parameter"><code>userParam</code></em> will be set to the value passed in the
             <em class="parameter"><code>userParam</code></em> parameter to the most recent call to <code class="function">glDebugMessageCallback</code>.
         </p>


### PR DESCRIPTION
Currently it's very hard to tell where the description of _length_ ends and _userParam_ starts in the documentation for `glDebugMessageCallback`.