### PR TITLE
Fix glVertexAttribDivisor version support table

### DIFF
--- a/gl4/glVertexAttribDivisor.xhtml
+++ b/gl4/glVertexAttribDivisor.xhtml
@@ -162,7 +162,7 @@
                 <td style="text-align: center; border-right: 2px solid ; ">-</td>
                 <td style="text-align: center; border-right: 2px solid ; ">-</td>
                 <td style="text-align: center; border-right: 2px solid ; ">-</td>
-                <td style="text-align: center; border-right: 2px solid ; ">✔</td>
+                <td style="text-align: center; border-right: 2px solid ; ">-</td>
                 <td style="text-align: center; border-right: 2px solid ; ">✔</td>
                 <td style="text-align: center; border-right: 2px solid ; ">✔</td>
                 <td style="text-align: center; border-right: 2px solid ; ">✔</td>


### PR DESCRIPTION
The version support table for the glVertexAttribDivisor function indicates support in 3.2+ contradicting the notes and the official documentation. This commit fixes this issue.