### PR TITLE
Replace incorrect atan with acos

### DIFF
--- a/sl4/acos.xhtml
+++ b/sl4/acos.xhtml
@@ -40,7 +40,7 @@
       <div class="refsect1" id="description">
         <h2>Description</h2>
         <p>
-            <code class="function">atan</code> returns the angle whose trigonometric cosine is
+            <code class="function">acos</code> returns the angle whose trigonometric cosine is
             <math overflow="scroll"><mi mathvariant="italic">x</mi></math>.
             The range of values returned by <code class="function">acos</code> is
             <math overflow="scroll">


### PR DESCRIPTION
The page describes the `acos` function, but text incorrectly said `atan`.