### PR TITLE
Improve search with Query Parameter and OpenSearch

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -99,7 +99,7 @@ for (dirpath, dirnames, filenames) in os.walk("html/copy"):
     
   d.append(dirpath)
   for file in filenames:
-    if file[-3:] != '.js' and file[-4:] != '.css' and file[-4:] != '.png' and file[-5:] != '.html' and file[-5:] != '.woff':
+    if file[-3:] != '.js' and file[-4:] != '.css' and file[-4:] != '.png' and file[-5:] != '.html' and file[-5:] != '.woff' and file != 'opensearch.xml':
       continue
     if file == 'Gruntfile.js':
       continue

--- a/html/copy/opensearch.xml
+++ b/html/copy/opensearch.xml
@@ -1,0 +1,6 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
+                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>docs.GL Search</ShortName>
+  <Description>Search the OpenGL API Documentation on docs.gl</Description>
+  <Url type="text/html" template="https://docs.gl/?search={searchTerms}"/>
+</OpenSearchDescription>

--- a/html/copy/opensearch.xml
+++ b/html/copy/opensearch.xml
@@ -1,6 +1,6 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
-                       xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-  <ShortName>docs.GL Search</ShortName>
-  <Description>Search the OpenGL API Documentation on docs.gl</Description>
-  <Url type="text/html" template="https://docs.gl/?search={searchTerms}"/>
+						xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+	<ShortName>docs.GL Search</ShortName>
+	<Description>Search the OpenGL API Documentation on docs.gl</Description>
+	<Url type="text/html" template="https://docs.gl/?search={searchTerms}"/>
 </OpenSearchDescription>

--- a/html/index.html
+++ b/html/index.html
@@ -165,6 +165,11 @@
 			});
 
 			$("#frontsearch").keyup(front_filter_fn);
+            let url_search = new URLSearchParams(window.location.search).get("search");
+            if (url_search) {
+                $("#frontsearch").val(url_search)
+                front_filter_fn()
+            }
 
 			$("#light-toggle").click(function() {
 				$("#pagestyle").attr("href", "style_light.css");

--- a/html/index.html
+++ b/html/index.html
@@ -12,7 +12,7 @@
 
 	<link href="style.css" rel="stylesheet" type="text/css" />
 	<link id="pagestyle" href="style_light.css" rel="stylesheet" type="text/css" />
-    <link rel="search" type="application/opensearchdescription+xml" title="docs.GL Search" href="opensearch.xml">
+	<link rel="search" type="application/opensearchdescription+xml" title="docs.GL Search" href="opensearch.xml">
 
 	<style>
 		#commandlist {
@@ -166,11 +166,11 @@
 			});
 
 			$("#frontsearch").keyup(front_filter_fn);
-            let url_search = new URLSearchParams(window.location.search).get("search");
-            if (url_search) {
-                $("#frontsearch").val(url_search)
-                front_filter_fn()
-            }
+			let url_search = new URLSearchParams(window.location.search).get("search");
+			if (url_search) {
+				$("#frontsearch").val(url_search)
+				front_filter_fn()
+			}
 
 			$("#light-toggle").click(function() {
 				$("#pagestyle").attr("href", "style_light.css");

--- a/html/index.html
+++ b/html/index.html
@@ -12,6 +12,7 @@
 
 	<link href="style.css" rel="stylesheet" type="text/css" />
 	<link id="pagestyle" href="style_light.css" rel="stylesheet" type="text/css" />
+    <link rel="search" type="application/opensearchdescription+xml" title="docs.GL Search" href="opensearch.xml">
 
 	<style>
 		#commandlist {


### PR DESCRIPTION
This pull will
- Add a few lines of Javascript to implement a ?search=abc query parameter
- Add an OpenSearch definition

In combination, these two features will allow Tab to Search from the URL bar.
See:
https://www.chromium.org/tab-to-search
https://developer.mozilla.org/en-US/docs/Web/OpenSearch
It will also be possible to link to a search query (if you want that for whatever reason).
I have tested the OpenSearch definition on localhost in Chrome and then changed the host from localhost to docs.gl - this means that the OpenSearch definition wont work locally (it will simply be ignored). 