### PR TITLE
Correct return type

### DIFF
--- a/sl4/memoryBarrier.xhtml
+++ b/sl4/memoryBarrier.xhtml
@@ -10,7 +10,7 @@
           <table style="border: 0; cellspacing: 0; cellpadding: 0;" class="funcprototype-table">
             <tr>
               <td>
-                <code class="funcdef">uint <strong class="fsfunc">memoryBarrier</strong>(</code>
+                <code class="funcdef">void <strong class="fsfunc">memoryBarrier</strong>(</code>
               </td>
               <td>void<code>)</code>;</td>
             </tr>


### PR DESCRIPTION
`memoryBarrier()` returns `void`, not `uint`. (From GLSL specifications 4.50 and 4.60.7, section 8.17.)