### PR TITLE
Update glClearBuffer.xhtml

### DIFF
--- a/gl4/glClearBuffer.xhtml
+++ b/gl4/glClearBuffer.xhtml
@@ -155,6 +155,10 @@
             </tr>
             <tr>
               <td> </td>
+              <td>GLint <var class="pdparam">drawbuffer</var>, </td>
+            </tr>
+            <tr>
+              <td> </td>
               <td>const GLfloat <var class="pdparam">depth</var>, </td>
             </tr>
             <tr>


### PR DESCRIPTION
Add the missed parameter `GLint drawbuffer` to **glClearNamedFramebufferfi**. 
(reference : https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glClearBuffer.xhtml)

(Fixing https://github.com/BSVino/docs.gl/issues/98)