### PR TITLE
Fixed error in glBindTexture

### DIFF
--- a/gl4/glBindTexture.xhtml
+++ b/gl4/glBindTexture.xhtml
@@ -146,7 +146,7 @@
             values.
         </p>
         <p>
-            <code class="constant">GL_INVALID_VALUE</code> is generated if <em class="parameter"><code>target</code></em> is not a name returned from
+            <code class="constant">GL_INVALID_VALUE</code> is generated if <em class="parameter"><code>texture</code></em> is not a name returned from
             a previous call to <a class="citerefentry" href="glGenTextures"><span class="citerefentry"><span class="refentrytitle">glGenTextures</span></span></a>.
         </p>
         <p>


### PR DESCRIPTION
Changed:
`GL_INVALID_VALUE` is generated if *target* is not a name returned from a previous call to `glGenTextures`.
to:
`GL_INVALID_VALUE` is generated if *texture* is not a name returned from a previous call to `glGenTextures`.

*`texture`* is the texture name returned by `glGenTextures`, not `target`.
https://docs.gl/gl4/glBindTexture