### PR TITLE
Fixed typo on textureGather and textureGatherOffset description.

### DIFF
--- a/el3/textureGather.xhtml
+++ b/el3/textureGather.xhtml
@@ -193,7 +193,7 @@
         <pre class="programlisting">    vec4(Sample_i0_j1(P, base).comp,
          Sample_i1_j1(P, base).comp,
          Sample_i1_j0(P, base).comp,
-         Sample_i0_j9(P, base).comp);</pre>
+         Sample_i0_j0(P, base).comp);</pre>
         <p>
     </p>
         <p>

--- a/el3/textureGatherOffset.xhtml
+++ b/el3/textureGatherOffset.xhtml
@@ -170,7 +170,7 @@
         <pre class="programlisting">    vec4(Sample_i0_j1(P + offset, base).comp,
          Sample_i1_j1(P + offset, base).comp,
          Sample_i1_j0(P + offset, base).comp,
-         Sample_i0_j9(P + offset, base).comp);</pre>
+         Sample_i0_j0(P + offset, base).comp);</pre>
         <p>
     </p>
         <p>


### PR DESCRIPTION
Hey,

This fix a simple typo in both GLSL _textureGather*_ description, here is some references from the official doc :
* https://www.khronos.org/registry/OpenGL-Refpages/es3.1/html/textureGather.xhtml
* https://www.khronos.org/registry/OpenGL-Refpages/es3.1/html/textureGatherOffset.xhtml

Thanks.