### PR TITLE
Fix typo in cross product formula (GLSL ES3)

### DIFF
--- a/el3/cross.xhtml
+++ b/el3/cross.xhtml
@@ -122,7 +122,7 @@
                             <mo>−</mo>
                             <mi>y</mi>
                             <mo stretchy="false">[</mo>
-                            <mn>1</mn>
+                            <mn>0</mn>
                             <mo stretchy="false">]</mo>
                             <mo lspace="2px" rspace="2px">⋅</mo>
                             <mi>x</mi>


### PR DESCRIPTION
As per #117 

The last row of the cross product formula is given as:
> 𝑥[0]⋅𝑦[1]−𝑦[1]⋅𝑥[1]

It should be:
> 𝑥[0]⋅𝑦[1]−𝑦[0]⋅𝑥[1]

This PR makes this change.