### PR TITLE
Fix the category auto-expand on page load

### DIFF
--- a/html/copy/docs.gl.js
+++ b/html/copy/docs.gl.js
@@ -222,20 +222,12 @@ $(function() {
 
 	if ($.cookie("pagestyle") == 'dark')
 		$("#style_dark").click();
-		
-	// hack to run after bonsai is initailized
-	setTimeout(function() {
-		$(".open_me").each(function() {
-			// copied from bonsai js to expand w/o animation
-			var listItem = $(this);
-			if( !listItem.data('subList') )
-				return;
-			listItem.addClass('expanded').removeClass('collapsed');
-			var subList = $(listItem.data('subList'));
-			subList.css('height', 'auto');
-		});
-	}, 1);
-	
+
+	$(".open_me").each(function() {
+		var category_to_open = $(this);
+		var category_bonsai = $( "#command_categories" ).data('bonsai');
+		category_bonsai.expand(category_to_open);
+	});
 
 	search_fn = function(value) {
 		var version = 'all';


### PR DESCRIPTION
Using the inlined code for bonsai's `expand()` function does not produce the desired result for reasons I admittedly do not understand. The comment claims this is to avoid the animation on page-load which I agree would be ideal but personally I'd rather have it animate and expand than not expand.

Changing the timeout from 1ms to 1000ms also appeared to work but I think that increases the level of "hackiness" whereas this reduces it.

This is to fix #120 