### PR TITLE
Fix compile process for python3 on Windows

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -5,6 +5,7 @@ import sys
 import argparse
 import re
 import zipfile
+import codecs
 
 import opengl
 import glsl
@@ -824,9 +825,8 @@ for version in major_versions:
     if command_file == False:
       raise IOError("Couldn't find page for command " + command + " (" + version + ")")
 
-    fp = open(command_file)
-    command_html = fp.read()
-    fp.close()
+    with codecs.open(command_file, mode="r", encoding="utf-8") as fp:
+        command_html = fp.read()
     
     if args.buildmode == 'full':
       command_html = command_html
@@ -942,12 +942,12 @@ for version in major_versions:
 
     output_html = header_for_command + command_html + footer_for_command
 
-    output = open(output_dir + version_dir + "/" + command, "w")
-    output_string = output_html
-    if args.buildmode == 'full':
-      output_string = htmlmin.minify(output_html, remove_comments=True, reduce_boolean_attributes=True, remove_optional_attribute_quotes=False).encode('ascii', 'xmlcharrefreplace').decode('ascii')
-    output.write(output_string)
-    output.close()
+    output_path = output_dir + version_dir + "/" + command
+    with codecs.open(output_path, mode="w", encoding="utf-8") as output:
+        output_string = output_html
+        if args.buildmode == 'full':
+          output_string = htmlmin.minify(output_html, remove_comments=True, reduce_boolean_attributes=True, remove_optional_attribute_quotes=False).encode('ascii', 'xmlcharrefreplace').decode('ascii')
+        output.write(output_string)
     
     written += 1
 


### PR DESCRIPTION
It's not clear whether python3 is supported. I would expect so considering that (as far as I know, I'm not usually a python developer) python2 is deprecated. The readme does not specify and the build.bat windows script explicitly calls out Python27 in the path.

As it stands python3 will fail to read in the input xhtml files because they contain bytes that are not valid using the default codepage on Windows (in English at least). Loading those files as utf-8 explicitly resolves this issue and is correct as long as all the xhtml files are utf-8 encoded. I have no idea what the encoding for those xhtml pages is intended to be but utf-8 seems like generally a reasonable assumption and it seems to work on the few pages I checked.