### PR TITLE
Navigate to search result on selection from the autocomplete dropdown

### DIFF
--- a/html/copy/docs.gl.js
+++ b/html/copy/docs.gl.js
@@ -291,7 +291,7 @@ $(function() {
 		source: search_versions["all"],
 		minLength: 3,
 		select: function( event, ui ) {
-			search_fn(event.target.value);
+			search_fn(ui.item.value);
 		},
 	});
 


### PR DESCRIPTION
This avoids needing to click on "Go" every time after you select the suggestion that you want, which I think is a significant quality-of-life improvement. The "Go" button still works as expected if you don't interact with the autocomplete at all.

Previously it looked like this:

![docsgl_auto_before](https://user-images.githubusercontent.com/4639662/182014776-59fad06d-f691-47f0-bb48-fffe4a217ea6.gif)

Now it looks like this:

![docsgl_auto_after](https://user-images.githubusercontent.com/4639662/182014675-5a6e4c0c-0bae-4645-86eb-7afcda95429c.gif)

It looks like this may have been the original intention and just wasn't working. The function to navigate to the search result was already being called when the user selects an autocomplete option, it was just passing in the text that the user had typed, rather than the text of the selected autocomplete option.