### PR TITLE
Fix typo

### DIFF
--- a/gl4/glFramebufferParameteri.xhtml
+++ b/gl4/glFramebufferParameteri.xhtml
@@ -139,7 +139,7 @@
             </dt>
             <dd>
               <p>
-                        <em class="parameter"><code>param</code></em> specifies the assumed with for a framebuffer object with no attachments. If a
+                        <em class="parameter"><code>param</code></em> specifies the assumed width for a framebuffer object with no attachments. If a
                         framebuffer has attachments then the width of those attachments is used, otherwise
                         the value of <code class="constant">GL_FRAMEBUFFER_DEFAULT_WIDTH</code> is used for the
                         framebuffer. <em class="parameter"><code>param</code></em> must be greater than or equal to zero and less than


### PR DESCRIPTION
Typo in glFramebufferParameteri ("with" instead of "width")