### PR TITLE
Update gl_CullDistance.xhtml

### DIFF
--- a/sl4/gl_CullDistance.xhtml
+++ b/sl4/gl_CullDistance.xhtml
@@ -31,10 +31,10 @@
             <em class="parameter"><code>gl_CullDistance</code></em>[<span class="emphasis"><em>i</em></span>]
             specifies a cull distance for each plane <span class="emphasis"><em>i</em></span>.
             A distance of 0.0 means that the vertex is on the plane, a
-            positive distance means that the vertex is insider the cull
+            positive distance means that the vertex is inside the cull
             volume, and a negative distance means that the point is outside
             the cull volume. Primitives whose vertices all have a negative
-            clip distance for plane <span class="emphasis"><em>i</em></span> will be
+            cull distance for plane <span class="emphasis"><em>i</em></span> will be
             discarded.
         </p>
         <p>


### PR DESCRIPTION
I updated a few things which I think are honest small mistakes.

Though that said I think the distance explanation for gl_ClipDistance and gl_CullDistance are really confusing.

Both have the same paragraph for describing what the distance means:

>  A distance of 0.0 means that the vertex is on the plane, a positive distance means that the vertex is insider the clip plane, and a negative distance means that the point is outside the clip plane. The clip distances will be linearly interpolated across the primitive and the portion of the primitive with interpolated distances less than 0.0 will be clipped. 

I have the problem specifically with "on a plane", "inside a plane" and "outside a plane" Since a plane has no volume I'd interpret the inside of a plane as being on the plane if I didn't have any graphics programming experience. Sure a plane can have orientation then you can have in front of a plane or behind a plane.

> A distance of 0.0 means that the vertex is on the plane, a positive distance means that the vertex is insider the cull volume, and a negative distance means that the point is outside the cull volume. Primitives whose vertices all have a negative clip distance for plane i will be discarded. 

Here I find it really strange that primitives outside the cull volume are discarded. I'd expect the primitives inside the cull volume to be discarded with and those outside the volume untouched.

That said I have not used these language features to be comfortable to changing the paragraphs themselves on my own. 
