### PR TITLE
Fix EndPrimitive

### DIFF
--- a/sl4/EndPrimitive.xhtml
+++ b/sl4/EndPrimitive.xhtml
@@ -23,7 +23,7 @@
         <p>
             <span class="emphasis"><em>Available only in the Geometry Shader</em></span>, <code class="function">EndPrimitive</code> completes the
             current output primitive on the first (and possibly only) vertex stream and starts a new one.No vertex is emitted.
-            Calling <code class="function">EndPrimitive</code> is equivalent to calling <a class="citerefentry" href="EmitStreamVertex"><span class="citerefentry"><span class="refentrytitle">EmitStreamVertex</span></span></a>
+            Calling <code class="function">EndPrimitive</code> is equivalent to calling <a class="citerefentry" href="EndStreamPrimitive"><span class="citerefentry"><span class="refentrytitle">EndStreamPrimitive</span></span></a>
             with <em class="parameter"><code>stream</code></em> set to 0.
         </p>
       </div>


### PR DESCRIPTION
Pretty sure this was wrong

Before:
> Calling `EndPrimitive` is equivalent to calling `EmitStreamVertex` with `stream` set to 0.

After:
> Calling `EndPrimitive` is equivalent to calling `EndStreamPrimitive` with `stream` set to 0.