### PR TITLE
DrawElementsIndirectCommand::baseVertex is signed integer

### DIFF
--- a/gl4/glMultiDrawElementsIndirect.xhtml
+++ b/gl4/glMultiDrawElementsIndirect.xhtml
@@ -134,7 +134,7 @@
         uint  count;
         uint  instanceCount;
         uint  firstIndex;
-        uint  baseVertex;
+        int  baseVertex;
         uint  baseInstance;
     } DrawElementsIndirectCommand;</pre>
         <p>


### PR DESCRIPTION
This can be confirmed by the specification ARB_draw_indirect or the signature of glDrawElements[Instanced]BaseVertex[BaseInstance]