### PR TITLE
glNamedBufferStorage and glNamedBufferData parameter size is GLsizeiptr

### DIFF
--- a/gl4/glBufferData.xhtml
+++ b/gl4/glBufferData.xhtml
@@ -38,7 +38,7 @@
             </tr>
             <tr>
               <td> </td>
-              <td>GLsizei <var class="pdparam">size</var>, </td>
+              <td>GLsizeiptr <var class="pdparam">size</var>, </td>
             </tr>
             <tr>
               <td> </td>

--- a/gl4/glBufferStorage.xhtml
+++ b/gl4/glBufferStorage.xhtml
@@ -38,7 +38,7 @@
             </tr>
             <tr>
               <td> </td>
-              <td>GLsizei <var class="pdparam">size</var>, </td>
+              <td>GLsizeiptr <var class="pdparam">size</var>, </td>
             </tr>
             <tr>
               <td> </td>


### PR DESCRIPTION
This can be confirmed by the specification ARB_direct_state_access.

This is important because according to [OpenGL Type](https://www.khronos.org/opengl/wiki/OpenGL_Type) `GLsizei` is always 32 bits wide but `GLsizeiptr` is platform dependent equivalent to `sizeof(void*)`.