### PR TITLE
Fix GL_INVALID_ENUM error reason in es3/glFramebufferTexture2D

### DIFF
--- a/es3/glFramebufferTexture2D.xhtml
+++ b/es3/glFramebufferTexture2D.xhtml
@@ -156,7 +156,7 @@
             <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>target</code></em> is not one of the accepted tokens.
         </p>
         <p>
-            <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>renderbuffertarget</code></em> is not <code class="constant">GL_RENDERBUFFER</code>.
+            <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>attachment</code></em> is not one of the attachment points listed above.
         </p>
         <p>
             <code class="constant">GL_INVALID_OPERATION</code> is generated if zero is bound to <em class="parameter"><code>target</code></em>.


### PR DESCRIPTION
there is a mistake in es3/glFramebufferTexture2D, referenced from https://registry.khronos.org/OpenGL-Refpages/es3/html/glFramebufferTexture2D.xhtml