### PR TITLE
modify the error situation that is inconsistent with the spec

### DIFF
--- a/gl4/glBindImageTexture.xhtml
+++ b/gl4/glBindImageTexture.xhtml
@@ -533,8 +533,10 @@
             is less than zero.
         </p>
         <p>
-            <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>access</code></em> or <em class="parameter"><code>format</code></em>
-            is not one of the supported tokens.
+            <code class="constant">GL_INVALID_ENUM</code> is generated if <em class="parameter"><code>access</code></em> is not one of the supported tokens.
+        </p>
+        <p>
+            <code class="constant">GL_INVALID_VALUE</code> is generated if <em class="parameter"><code>format</code></em> is not one of the supported tokens.
         </p>
       </div>
       <div class="refsect1" id="associatedgets">


### PR DESCRIPTION
According to the description on page 266 of glspec42.core: format specifies the format that the elements of the image will be treated as when doing formatted stores, as described later in this section. This is referred to as the image unit format. This must be one of the formats listed in table 3.21;**otherwise, the error INVALID_VALUE is generated.**
The error situation of format has been modified.

This is my first time submitting a contribution to an open source repository. Please correct my mistakes. Thank you.