### PR TITLE
Offline mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,15 @@ using the local copies. It looks like this:
 If you are running Windows, there are a build.bat and a build_full.bat for convenience. When
 the script is done building, the completed site will be in a folder named `htdocs`.
 
+Offline Viewing
+---------------
+First compile the files using the `--local-assets` flag, while in the root project directory run 
+`python start_offline_webserver.py` which starts a local webserver on port 8000 which can be accessed
+in your browser by going to the url `http://localhost:8000`. 
+
+If you find that any functionality is missing, please open a pull request.
+
+
 File Structure
 --------------
 

--- a/start_offline_webserver.py
+++ b/start_offline_webserver.py
@@ -1,0 +1,16 @@
+import http.server
+import socketserver
+import os
+
+os.chdir('htdocs');
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    extensions_map = http.server.SimpleHTTPRequestHandler.extensions_map.copy()
+    extensions_map[''] = 'text/html'
+
+
+host = "localhost"
+port = 8000
+with socketserver.TCPServer((host, port), Handler) as httpd:
+    print(f"serving docs at http://{host}:{port}")
+    httpd.serve_forever()


### PR DESCRIPTION
add  a python script which starts an offline webserver and add description on how to use in the readme.

the script code comes from https://github.com/BSVino/docs.gl/issues/102#issuecomment-1435981395 and only modifies it slightly to move to the output dir before starting the webserver. 

Also note that after getting to a docs page for a specific function, if you try and use the search feature in the top right then nothing happens. So if this gets merged we should add an issue for that.

If merged, we can close #102 