### PR TITLE
Fix wrong parameter type in glNamedBufferSubData

### DIFF
--- a/gl4/glBufferSubData.xhtml
+++ b/gl4/glBufferSubData.xhtml
@@ -41,7 +41,7 @@
             </tr>
             <tr>
               <td> </td>
-              <td>GLsizei <var class="pdparam">size</var>, </td>
+              <td>GLsizeiptr <var class="pdparam">size</var>, </td>
             </tr>
             <tr>
               <td> </td>


### PR DESCRIPTION
Noticed a small mistake in the [glBufferSubData](https://docs.gl/gl4/glBufferSubData) entry, specifically for the `size` parameter in `glNamedBufferSubData`. As per official documentation: [glBufferSubData](https://registry.khronos.org/OpenGL-Refpages/gl4/html/glBufferSubData.xhtml), the `size` parameter for glNamedBufferSubData should be `GLsizeiptr`, not `GLsizei`.

I was a little confused how copyright/licensing works with this project, if there is any changes I need to make for that let me know. Otherwise consider it in the public domain :)