### PR TITLE
fix specifications for indirect draws

### DIFF
--- a/gl4/glDrawArraysIndirect.xhtml
+++ b/gl4/glDrawArraysIndirect.xhtml
@@ -61,7 +61,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies the address of a structure containing the draw parameters.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_DRAW_INDIRECT_BUFFER</code>
+                    to start reading indirect draw parameters from.
                 </p>
             </dd>
           </dl>
@@ -95,7 +96,8 @@
             If a buffer is bound to the <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding at the time
             of a call to <code class="function">glDrawArraysIndirect</code>, <em class="parameter"><code>indirect</code></em>
             is interpreted as an offset, in basic machine units, into that buffer and the parameter
-            data is read from the buffer rather than from client memory.
+            data is read from the buffer. If no buffer is bound to the
+            <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding, an error will be generated.
         </p>
         <p>
             In contrast to <a class="citerefentry" href="glDrawArraysInstancedBaseInstance"><span class="citerefentry"><span class="refentrytitle">glDrawArraysInstancedBaseInstance</span></span></a>,

--- a/gl4/glDrawElementsIndirect.xhtml
+++ b/gl4/glDrawElementsIndirect.xhtml
@@ -77,7 +77,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies the address of a structure containing the draw parameters.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_DRAW_INDIRECT_BUFFER</code>
+                    to start reading indirect draw parameters from.
                 </p>
             </dd>
           </dl>
@@ -126,7 +127,8 @@
             If a buffer is bound to the <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding at the time
             of a call to <code class="function">glDrawElementsIndirect</code>, <em class="parameter"><code>indirect</code></em>
             is interpreted as an offset, in basic machine units, into that buffer and the parameter
-            data is read from the buffer rather than from client memory.
+            data is read from the buffer. If no buffer is bound to the
+            <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding, an error will be generated.
         </p>
         <p>
             Note that indices stored in client memory are not supported. If no buffer is bound to the
@@ -158,7 +160,7 @@
         </p>
         <p>
             <code class="constant">GL_INVALID_OPERATION</code> is generated if no buffer is bound to the <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
-            binding, or if such a buffer's data store is currently mapped.
+            or <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding, or if such a buffer's data store is currently mapped.
         </p>
         <p>
             <code class="constant">GL_INVALID_OPERATION</code> is generated if a non-zero buffer object name is bound to an

--- a/gl4/glMultiDrawArraysIndirect.xhtml
+++ b/gl4/glMultiDrawArraysIndirect.xhtml
@@ -69,7 +69,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies the address of an array of structures containing the draw parameters.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_DRAW_INDIRECT_BUFFER</code>
+                    to start reading indirect draw parameters from.
                 </p>
             </dd>
             <dt>
@@ -143,7 +144,8 @@
             If a buffer is bound to the <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding at the time
             of a call to <code class="function">glMultiDrawArraysIndirect</code>, <em class="parameter"><code>indirect</code></em>
             is interpreted as an offset, in basic machine units, into that buffer and the parameter
-            data is read from the buffer rather than from client memory.
+            data is read from the buffer. If no buffer is bound to the
+            <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding, an error will be generated.
         </p>
         <p>
             In contrast to <a class="citerefentry" href="glDrawArraysInstancedBaseInstance"><span class="citerefentry"><span class="refentrytitle">glDrawArraysInstancedBaseInstance</span></span></a>,

--- a/gl4/glMultiDrawElementsIndirect.xhtml
+++ b/gl4/glMultiDrawElementsIndirect.xhtml
@@ -85,7 +85,8 @@
             </dt>
             <dd>
               <p>
-                    Specifies the address of a structure containing an array of draw parameters.
+                    Specifies a byte offset (cast to a pointer type) into the buffer bound to <code class="constant">GL_DRAW_INDIRECT_BUFFER</code>
+                    to start reading indirect draw parameters from.
                 </p>
             </dd>
             <dt>
@@ -166,7 +167,8 @@
             If a buffer is bound to the <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding at the time
             of a call to <code class="function">glDrawElementsIndirect</code>, <em class="parameter"><code>indirect</code></em>
             is interpreted as an offset, in basic machine units, into that buffer and the parameter
-            data is read from the buffer rather than from client memory.
+            data is read from the buffer. If no buffer is bound to the
+            <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding, an error will be generated.
         </p>
         <p>
             Note that indices stored in client memory are not supported. If no buffer is bound to the
@@ -205,7 +207,7 @@
         </p>
         <p>
             <code class="constant">GL_INVALID_OPERATION</code> is generated if no buffer is bound to the <code class="constant">GL_ELEMENT_ARRAY_BUFFER</code>
-            binding, or if such a buffer's data store is currently mapped.
+            or <code class="constant">GL_DRAW_INDIRECT_BUFFER</code> binding, or if such a buffer's data store is currently mapped.
         </p>
         <p>
             <code class="constant">GL_INVALID_OPERATION</code> is generated if a non-zero buffer object name is bound to an


### PR DESCRIPTION
Fixed documentation specification to be consistent with `ARB_draw_indirect` specification for core profile.

As per paragraph:

```
    Initially zero is bound to DRAW_INDIRECT_BUFFER. In the
    compatibility profile, this indicates that DrawArraysIndirect and
    DrawElementsIndirect are to source their arguments directly from the 
    pointer passed as their <indirect> parameters. In the core profile,
    an INVALID_OPERATION error is generated if zero is bound to
    DRAW_INDIRECT_BUFFER and DrawArraysIndirect or DrawElementsIndirect
    is called.
```

I haven't added compatibility profile behavior (that seems to be current state), since it could bring confusion.