### PR TITLE
Update initial values for GL_POINT_SIZE_MAX and GL_POINT_SIZE_MIN

### DIFF
--- a/gl2/glGet.xhtml
+++ b/gl2/glGet.xhtml
@@ -1418,12 +1418,12 @@
                     </p></dd><dt><span class="term"><code class="constant">GL_POINT_SIZE_MAX</code></span></dt><dd><p>
 			  </p><p>
                         <em class="parameter"><code>params</code></em> returns one value,
-                        the upper bound for the attenuated point sizes.  The initial value is 0.0.
+                        the upper bound for the attenuated point sizes.  The initial value is 1.0.
                         See <a class="citerefentry" href="glPointParameter"><span class="citerefentry"><span class="refentrytitle">glPointParameter</span></span></a>.
                     </p></dd><dt><span class="term"><code class="constant">GL_POINT_SIZE_MIN</code></span></dt><dd><p>
 			  </p><p>
                         <em class="parameter"><code>params</code></em> returns one value,
-                        the lower bound for the attenuated point sizes. The initial value is 1.0.
+                        the lower bound for the attenuated point sizes. The initial value is 0.0.
                         See <a class="citerefentry" href="glPointParameter"><span class="citerefentry"><span class="refentrytitle">glPointParameter</span></span></a>.
                     </p></dd><dt><span class="term"><code class="constant">GL_POINT_SIZE_RANGE</code></span></dt><dd><p>
 			  </p><p>


### PR DESCRIPTION
docs.gl/gl2/glPointParameter is consistent with the spec: it says min = 0.0, max = 1.0.

docs.gl/gl2/glGet appears to have them swapped: it says GL_POINT_SIZE_MAX initial value is 0.0 and GL_POINT_SIZE_MIN initial value is 1.0, which contradicts the spec.